### PR TITLE
test watch option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ node_js:
 script:
   - cp .env.travis .env
   - npm run stat
-  - npm test
+  - npm test -- --ci
   - npm run build
 after_script:
   - npm install coveralls

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,8 +29,8 @@ test_script:
   - node -e 'console.log(process.env);'
   # We test multiple Windows shells because of prior stdout buffering issues
   # filed against Grunt. https://github.com/joyent/node/issues/3584
-  - ps: "npm test # PowerShell" # Pass comment to PS for easier debugging
-  - cmd: npm test
+  - ps: "npm test -- --ci # PowerShell" # Pass comment to PS for easier debugging
+  - cmd: npm test -- --ci
 
 cache:
   - node_modules -> package.json                                        # local npm modules

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,6 +1,7 @@
 var webpackConfig = require('./config/webpack/webpack.test');
 
 module.exports = function (config) {
+
   var _config = {
     basePath: '',
 
@@ -42,9 +43,9 @@ module.exports = function (config) {
     port: 9876,
     colors: true,
     logLevel: config.LOG_INFO,
-    autoWatch: false,
+    autoWatch: !config.ci,
     browsers: ['PhantomJS'],
-    singleRun: true
+    singleRun: config.ci
   };
 
   config.set(_config);


### PR DESCRIPTION
**BREAKING CHANGE**
- Now `npm test` will always autowatch. For testing in CI environment, please use `npm test -- --ci`